### PR TITLE
[configuration] Move sensitive information from application.properties to .env file

### DIFF
--- a/.github/workflows/gradle.yaml
+++ b/.github/workflows/gradle.yaml
@@ -31,16 +31,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: make application.yml
+      - name: make .env
         run: |
-          mkdir -p ./src/main/resources
-          cd ./src/main/resources
-          touch ./application.yml
-          touch ./application-common.yml
-          touch ./application-prod.yml
-          echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./application.properties
-          echo "${{ secrets.COMMON }}" > ./application-common.yml
-          echo "${{ secrets.PROD }}" > ./application-production.yml
+          touch ./.env
+          echo "${{ SECRETS.ENV }} > ./.env
 
       - name: Grant execute permission for gradle
         run: chmod +x ./gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -47,21 +47,17 @@ out/
 ### OS files ###
 .DS_Store
 
-### Configuration files ###
-application.properties
-application.yml
-
-# Compiled class file
+### Compiled class file ###
 *.class
 *.swp
 
-# BlueJ files
+### BlueJ files ###
 *.ctxt
 
-# Mobile Tools for Java (J2ME)
+### Mobile Tools for Java (J2ME) ###
 .mtj.tmp/
 
-# Package Files #
+### Package Files ###
 *.jar
 *.war
 *.nar
@@ -70,6 +66,9 @@ application.yml
 *.tar.gz
 *.rar
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+### virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml ###
 hs_err_pid*
 replay_pid*
+
+### environment variable file ###
+.env

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,26 @@
+spring.application.name=plowers
+
+# Import .env file
+spring.config.import=optional:file:.env[.properties]
+
+# Google OAuth2
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_OAUTH2_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_OAUTH2_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=profile, email
+spring.security.oauth2.client.registration.google.redirect-uri={baseUrl}/login/oauth2/code/google
+spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.google.client-name=Google
+spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/auth
+spring.security.oauth2.client.provider.google.token-uri=https://oauth2.googleapis.com/token
+spring.security.oauth2.client.provider.google.user-info-uri=https://www.googleapis.com/oauth2/v3/userinfo
+
+# Database
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_MASTER_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
+
+spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.MySQLDialect
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true


### PR DESCRIPTION
- Using `.env` file for manage environment variable only
- Upload `application.properties` on GitHub and ignore .`env` file
- Edit `.github/workflows/gradle.yml` for making `.env` file using GitHub secrets instead of application.properties